### PR TITLE
Bigger cleanup and move docs to the main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Distributed Tracing: LoggingContext / Baggage
+# 🧳 Distributed Tracing: LoggingContext / Baggage
 
 [![Swift 5.2](https://img.shields.io/badge/Swift-5.2-ED523F.svg?style=flat)](https://swift.org/download/)
 [![Swift 5.1](https://img.shields.io/badge/Swift-5.1-ED523F.svg?style=flat)](https://swift.org/download/)


### PR DESCRIPTION
The docs were getting too duplicated; let's just have them in the main repo; Barely anyone will be looking at this one here.