### PR TITLE
Enable strict concurrency checking in CI

### DIFF
--- a/docker/docker-compose.2004.58.yaml
+++ b/docker/docker-compose.2004.58.yaml
@@ -14,6 +14,7 @@ services:
     environment:
       #- SANITIZER_ARG=--sanitize=thread
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: swift-service-context:20.04-5.8

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -14,6 +14,7 @@ services:
     environment:
       #- SANITIZER_ARG=--sanitize=thread
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: swift-service-context:22.04-5.9

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -14,6 +14,7 @@ services:
     environment:
       #- SANITIZER_ARG=--sanitize=thread
       - FORCE_TEST_DISCOVERY=--enable-test-discovery
+      - STRICT_CONCURRENCY_ARG=-Xswiftc -strict-concurrency=complete
 
   shell:
     image: swift-service-context:22.04-main

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${FORCE_TEST_DISCOVERY-} $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${FORCE_TEST_DISCOVERY-} $${SANITIZER_ARG-} $${STRICT_CONCURRENCY_ARG-}"
 
   # util
 


### PR DESCRIPTION
## Summary

To help avoid concurrency bugs, enabled complete concurrency checking in CI.

Added the compiler flag to the docker-compose scripts, and verified that currently there are no warnings with this flag enabled.

Separately, it might make sense to enable warnings-as-errors on this repo to help avoid new warnings.

## Test Plan

Verified locally that the repo produces no concurrency warnings.
