### PR TITLE
- fixes the disambigutation link for ServiceContextKey.nameOverride - minor updates and tightening of grammar

### DIFF
--- a/Sources/ServiceContextModule/ServiceContext.swift
+++ b/Sources/ServiceContextModule/ServiceContext.swift
@@ -233,7 +233,7 @@ extension ServiceContext {
 #if swift(>=5.5) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension ServiceContext {
-    /// A `ServiceContext` is propagated through task-local storage. This API enables binding a top-level `ServiceContext` and
+    /// A `ServiceContext` is automatically propagated through task-local storage. This API enables binding a top-level `ServiceContext` and
     /// implicitly passes it to child tasks when using structured concurrency.
     @TaskLocal public static var current: ServiceContext?
 

--- a/Sources/ServiceContextModule/ServiceContext.swift
+++ b/Sources/ServiceContextModule/ServiceContext.swift
@@ -233,8 +233,8 @@ extension ServiceContext {
 #if swift(>=5.5) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension ServiceContext {
-    /// A `ServiceContext` automatically propagated through task-local storage. This API enables binding a top-level `ServiceContext` and passing it
-    /// implicitly to any child tasks when using structured concurrency.
+    /// A `ServiceContext` is propagated through task-local storage. This API enables binding a top-level `ServiceContext` and
+    /// implicitly passes it to child tasks when using structured concurrency.
     @TaskLocal public static var current: ServiceContext?
 
     /// Convenience API to bind the task-local ``ServiceContext/current`` to the passed `value`, and execute the passed `operation`.

--- a/Sources/ServiceContextModule/ServiceContextKey.swift
+++ b/Sources/ServiceContextModule/ServiceContextKey.swift
@@ -14,9 +14,9 @@
 //===----------------------------------------------------------------------===//
 
 /// Baggage keys provide type-safe access to ``ServiceContext``s by declaring the type of value they "key" at compile-time.
-/// To give your `ServiceContextKey` an explicit name you may override the ``ServiceContextKey/nameOverride-2upe8`` property.
+/// To give your `ServiceContextKey` an explicit name, override the ``ServiceContextKey/nameOverride-6shk1`` property.
 ///
-/// In general, `ServiceContextKey`s should be `internal` or `private` to the part of a system using it.
+/// In general, any `ServiceContextKey` should be `internal` or `private` to the part of a system using it.
 ///
 /// All access to context items should be performed through an accessor computed property defined as shown below:
 ///
@@ -63,7 +63,7 @@ extension ServiceContextKey {
 
 /// A type-erased ``ServiceContextKey`` used when iterating through the ``ServiceContext`` using its `forEach` method.
 public struct AnyServiceContextKey: _ServiceContext_Sendable {
-    /// The key's type represented erased to an `Any.Type`.
+    /// The key's type erased to `Any.Type`.
     public let keyType: Any.Type
 
     private let _nameOverride: String?


### PR DESCRIPTION
Hit another broken link scenario when viewing docs on SwiftPackageIndex for this package. This fixes the disambiguation to one of the two overloads (they seemed functionally equivalent), and I tightened up some grammar and sentences in nearby descriptions while I was reading.

If the grammar updates are undesired, I can back those out and just fix the disambiguation to resolve the link properly.