### PR TITLE
Fix deprecated message it cannot handle in swift6 (in 5 mode)

### DIFF
--- a/Sources/ServiceContextModule/ServiceContext.swift
+++ b/Sources/ServiceContextModule/ServiceContext.swift
@@ -244,7 +244,7 @@ extension ServiceContext {
     /// To access the task-local value, use `ServiceContext.current`.
     ///
     /// SeeAlso: [Swift Task Locals](https://developer.apple.com/documentation/swift/tasklocal)
-    #if swift(>=6.0)
+    #if compiler(>=6.0)
     public static func withValue<T>(_ value: ServiceContext?,
                                     isolation: isolated(any Actor)? = #isolation,
                                     operation: () async throws -> T) async rethrows -> T

--- a/Sources/ServiceContextModule/ServiceContext.swift
+++ b/Sources/ServiceContextModule/ServiceContext.swift
@@ -253,8 +253,10 @@ extension ServiceContext {
     }
     #endif
 
+    #if compiler(>=6.0)
     @available(*, deprecated, message: "Prefer withValue(_:isolation:operation:)")
     @_disfavoredOverload
+    #endif
     @_unsafeInheritExecutor // Deprecated trick to avoid executor hop here; 6.0 introduces the proper replacement: #isolation
     public static func withValue<T>(_ value: ServiceContext?, operation: () async throws -> T) async rethrows -> T {
         try await ServiceContext.$current.withValue(value, operation: operation)

--- a/Tests/ServiceContextTests/ServiceContextTests.swift
+++ b/Tests/ServiceContextTests/ServiceContextTests.swift
@@ -86,7 +86,6 @@ final class ServiceContextTests: XCTestCase {
         #endif
     }
 
-    #if swift(>=5.7)
     actor SomeActor {
         var value: Int = 0
 
@@ -97,9 +96,11 @@ final class ServiceContextTests: XCTestCase {
             ServiceContext.withValue(.topLevel) {
                 value = 12 // should produce no warnings
             }
+            await ServiceContext.withValue(.topLevel) { () async in
+                value = 12 // should produce no warnings
+            }
         }
     }
-    #endif
 
     private enum FirstTestKey: ServiceContextKey {
         typealias Value = Int


### PR DESCRIPTION
When using swift-language-mode 5 with Swift 6, I can't handle the deprecated message displayed for `ServiceContext.withValue`.
The conditional `#if swift(>=6.0)` is only effective with swift-language-mode 6 and not with mode 5. I believe the correct specification is `#if compiler(>=6.0)`.
Additionally, the deprecated message always appears in Swift 5, which I also cannot handle.

This PR fix the issue so that warnings do not appear in swift-language-mode 5 and swift-language-mode 6 of Swift 6, as well as in Swift 5.10.