### PR TITLE
Fix typo issue from `propagages` to `propagates`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ let c = ServiceContext.withValue(context) {
 assert(c == 42)
 ```
 
-`ServiceContext` is a fundamental building block for how distributed tracing propagages trace identifiers.
+`ServiceContext` is a fundamental building block for how distributed tracing propagates trace identifiers.
 
 ## Dependency
 


### PR DESCRIPTION
Fix typo issue from `propagages` to `propagates`.