### PR TITLE
Enable strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,3 +42,9 @@ let package = Package(
         ),
     ]
 )
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    target.swiftSettings = settings
+}


### PR DESCRIPTION
### Motivation:

Catch potential data races at build time.

### Modifications:

Enabled strict concurrency complete checking.

### Result:

Fewer potential data races can sneak in.
