### PR TITLE
forEach can be Sendable values; storage already is Sendable

### DIFF
--- a/Sources/ServiceContextModule/ServiceContext.swift
+++ b/Sources/ServiceContextModule/ServiceContext.swift
@@ -219,6 +219,7 @@ extension ServiceContext {
     ///
     /// - Parameter body: The closure to be invoked for each item stored in this `ServiceContext`,
     /// passing the type-erased key and the associated value.
+    @preconcurrency
     public func forEach(_ body: (AnyServiceContextKey, any Sendable) throws -> Void) rethrows {
         // swift-format-ignore: ReplaceForEachWithForLoop
         try self._storage.forEach { key, value in

--- a/Sources/ServiceContextModule/ServiceContext.swift
+++ b/Sources/ServiceContextModule/ServiceContext.swift
@@ -219,7 +219,7 @@ extension ServiceContext {
     ///
     /// - Parameter body: The closure to be invoked for each item stored in this `ServiceContext`,
     /// passing the type-erased key and the associated value.
-    public func forEach(_ body: (AnyServiceContextKey, Any) throws -> Void) rethrows {
+    public func forEach(_ body: (AnyServiceContextKey, any Sendable) throws -> Void) rethrows {
         // swift-format-ignore: ReplaceForEachWithForLoop
         try self._storage.forEach { key, value in
             try body(key, value)


### PR DESCRIPTION
Trivial change for the foreach to expose Sendable values -- they already are in storage, so the function should not lose that info