### PR TITLE
Add lightweight proposals process to swift-service-context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,8 @@ directory, for example:
 
 ## How to contribute your work
 
+For non-trivial changes that affect the public API, it is good practice to have a discussion phase before writing code. Please follow the [proposal process](Sources/ServiceContextModule/Docs.docc/Proposals/Proposals.md) to gather feedback and align on the approach with other contributors.
+
 Please open a pull request at https://github.com/apple/swift-service-context. Make sure the CI passes, and then wait for code review.
 
 ## Automated release process

--- a/Sources/ServiceContextModule/Docs.docc/Proposals/Proposals.md
+++ b/Sources/ServiceContextModule/Docs.docc/Proposals/Proposals.md
@@ -1,0 +1,47 @@
+# Proposals
+
+Collaborate on API changes to Swift Service Context by writing a proposal.
+
+## Overview
+
+For non-trivial changes that affect the public API, the Swift Service Context project adopts a lightweight version of
+the [Swift Evolution](https://github.com/apple/swift-evolution/blob/main/process.md) process.
+
+Writing a proposal first helps you discuss multiple possible solutions early, apply useful feedback from other
+contributors, and avoid reimplementing the same feature multiple times.
+
+Get feedback early by opening a pull request with your proposal, but also consider the complexity of the implementation
+when evaluating different solutions. For example, include a link to a branch containing a prototype implementation of
+the feature in the pull request description.
+
+> Note: The goal of this process is to solicit feedback from the whole community around the project, and the project
+> continues to refine the proposal process itself. Use your best judgment, and don't hesitate to propose changes to
+> the proposal structure itself.
+
+### Steps
+
+1. Make sure there's a GitHub issue for the feature or change you would like to propose.
+2. Duplicate the `SSC-NNNN.md` document and replace `NNNN` with the next available proposal number.
+3. Link the GitHub issue from your proposal, and fill in the proposal.
+4. Open a pull request with your proposal and solicit feedback from other contributors.
+5. Once a maintainer confirms that the proposal is ready for review, we update the state accordingly. The review period
+   is 7 days, and ends when one of the maintainers marks the proposal as Ready for Implementation, or Deferred.
+6. Before merging the pull request, ensure an implementation is ready, either in the same pull request or in a separate
+   one linked from the proposal.
+7. A proposal becomes Approved once you merge the implementation and proposal PRs, and enable any feature flags
+   unconditionally.
+
+If you have any questions, ask in an issue on GitHub.
+
+### Possible review states
+
+- Awaiting Review
+- In Review
+- Ready for Implementation
+- In Preview
+- Approved
+- Deferred
+
+## Topics
+
+- <doc:SSC-NNNN>

--- a/Sources/ServiceContextModule/Docs.docc/Proposals/SSC-NNNN.md
+++ b/Sources/ServiceContextModule/Docs.docc/Proposals/SSC-NNNN.md
@@ -1,0 +1,50 @@
+# SSC-NNNN: Feature name
+
+Feature abstract – a one sentence summary.
+
+## Overview
+
+- Proposal: SSC-NNNN
+- Author(s): [Author 1](https://github.com/swiftdev), [Author 2](https://github.com/swiftdev)
+- Status: **Awaiting Review**
+- Issue: [apple/swift-service-context#1](https://github.com/apple/swift-service-context/issues/1)
+- Implementation:
+    - [apple/swift-service-context#1](https://github.com/apple/swift-service-context/pull/1)
+- Feature flag: `proposalNNNN`
+- Related links:
+    - [Lightweight proposals process description](https://github.com/apple/swift-service-context/blob/main/Sources/ServiceContextModule/Docs.docc/Proposals/Proposals.md)
+
+### Introduction
+
+A short, one-sentence overview of the feature or change.
+
+### Motivation
+
+Describe the problems that this proposal addresses, and what workarounds adopters currently use, if any.
+
+### Proposed solution
+
+Describe your solution to the problem. Provide examples and describe how they work. Show how your solution is better
+than current workarounds.
+
+Focus this section on what will change for the _adopters_ of Swift Service Context.
+
+### Detailed design
+
+Describe the implementation of the feature. Include a link to a prototype implementation.
+
+Focus this section on what will change for the _contributors_ to Swift Service Context.
+
+### API stability
+
+Discuss the API implications, making sure to consider all of:
+- existing ``ServiceContext`` users
+- existing ``ServiceContextKey`` implementations
+
+### Future directions
+
+Discuss any potential future improvements to the feature.
+
+### Alternatives considered
+
+Discuss the alternative solutions you considered, even during the review process itself.

--- a/Sources/ServiceContextModule/Docs.docc/index.md
+++ b/Sources/ServiceContextModule/Docs.docc/index.md
@@ -59,3 +59,7 @@ Please refer to in-depth discussion and documentation in the [Swift Distributed 
 - ``AnyServiceContextKey``
 - ``TODOLocation``
 
+### Contribute to the project
+
+- <doc:Proposals>
+


### PR DESCRIPTION
For non-trivial changes that affect the public API, the SwiftLog project adopts a lightweight version of the [Swift Evolution](https://github.com/apple/swift-evolution/blob/main/process.md) process.

## Motivation:

Writing a proposal first helps discuss multiple possible solutions early, apply useful feedback from other contributors, and avoid reimplementing the same feature multiple times.

## Modifications:

Proposals process description and a proposal template added to the documentation.

## Result:

Proposals can now be submitted to the Swift Service Context.